### PR TITLE
[Breaking] Improve request typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.1.1 - 2023-12-22
+## 0.2.0
+
+- `RequestManager.send` now only accepts a single generic argument, `TResponse`, which is the type of the response body. The `TRequest` type argument has been removed. The type of the Response will be inferred based on the given `Request<Response>` (#3)
+
+## 0.1.1
 
 - Add `registerFactory` and `registerFunction` methods to `RequestManager`.
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Future<void> main() async {
 
   mediator.requests.register(MyQueryHandler());
 
-  final response = await mediator.requests
-    .send<Something, MyQuery>(MyQuery());
+  final Something response = await mediator.requests.send(MyQuery());
 
   print(response);
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -23,6 +23,10 @@ Future<void> main() async {
         (count) => print('[CountEvent handler] received count: $count'),
       );
 
+  mediator.events.on<CountEvent>().subscribeFunction(
+        (count) => print('[Other Event Handler] received: $count'),
+      );
+
   const getUserQuery = GetUserByIdQuery(123);
 
   print('Sending $getUserQuery request');

--- a/example/example.dart
+++ b/example/example.dart
@@ -20,7 +20,7 @@ Future<void> main() async {
       .map((event) => event.count)
       .distinct()
       .subscribeFunction(
-        (count) => print('[$CountEvent handler] received count: $count'),
+        (count) => print('[CountEvent handler] received count: $count'),
       );
 
   const getUserQuery = GetUserByIdQuery(123);
@@ -29,7 +29,7 @@ Future<void> main() async {
 
   final resp = await mediator.requests.send(getUserQuery);
 
-  print('Got $GetUserByIdQuery response: $resp');
+  print('Got $getUserQuery response: $resp');
 
   print('---');
 
@@ -57,7 +57,7 @@ class CountEvent implements DomainEvent {
   const CountEvent(this.count);
 
   @override
-  String toString() => '$CountEvent(count: $count)';
+  String toString() => 'CountEvent(count: $count)';
 }
 
 class MyCommand implements Command {
@@ -65,15 +65,15 @@ class MyCommand implements Command {
   const MyCommand(this.command);
 
   @override
-  String toString() => '$MyCommand(command: $command)';
+  String toString() => 'MyCommand(command: $command)';
 }
 
 class MyCommandHandler implements CommandHandler<MyCommand> {
   @override
   Future<void> handle(MyCommand request) async {
-    print('[$MyCommandHandler] Executing "$request"');
+    print('[MyCommandHandler] Executing "$request"');
     await Future.delayed(const Duration(milliseconds: 500));
-    print('[$MyCommandHandler] "$request" completed');
+    print('[MyCommandHandler] "$request" completed');
   }
 }
 
@@ -82,15 +82,15 @@ class GetUserByIdQuery implements Query<User> {
   const GetUserByIdQuery(this.userId);
 
   @override
-  String toString() => '$GetUserByIdQuery(userId: $userId)';
+  String toString() => 'GetUserByIdQuery(userId: $userId)';
 }
 
 class GetUserByIdQueryHandler implements QueryHandler<User, GetUserByIdQuery> {
   @override
   Future<User> handle(GetUserByIdQuery request) async {
-    print('[$GetUserByIdQueryHandler] handeling $request');
+    print('[GetUserByIdQueryHandler] handeling $request');
     final user = await getUserByIdAsync(request.userId);
-    print('[$GetUserByIdQueryHandler] got $user');
+    print('[GetUserByIdQueryHandler] got $user');
     return user;
   }
 }
@@ -99,10 +99,10 @@ class LoggingBehavior implements PipelineBehavior {
   @override
   Future handle(request, RequestHandlerDelegate next) async {
     try {
-      print('[$LoggingBehavior] [${request.runtimeType}] Before');
+      print('[LoggingBehavior] [$request] Before');
       return await next();
     } finally {
-      print('[$LoggingBehavior] [${request.runtimeType}] After');
+      print('[LoggingBehavior] [$request] After');
     }
   }
 }
@@ -114,7 +114,7 @@ class LoggingEventObserver implements EventObserver {
     Set<EventHandler<TEvent>> handlers,
   ) {
     print(
-      '[$LoggingEventObserver] onDispatch "$event" with ${handlers.length} handlers',
+      '[LoggingEventObserver] onDispatch "$event" with ${handlers.length} handlers',
     );
   }
 
@@ -125,7 +125,7 @@ class LoggingEventObserver implements EventObserver {
     Object error,
     StackTrace stackTrace,
   ) {
-    print('[$LoggingEventObserver] onError $event -> $handler ($error)');
+    print('[LoggingEventObserver] onError $event -> $handler ($error)');
   }
 
   @override
@@ -142,7 +142,7 @@ class User {
   const User(this.id, this.name);
 
   @override
-  String toString() => '$User(id: $id, name: $name)';
+  String toString() => 'User(id: $id, name: $name)';
 }
 
 Future<User> getUserByIdAsync(int id) async {

--- a/example/example.dart
+++ b/example/example.dart
@@ -27,8 +27,7 @@ Future<void> main() async {
 
   print('Sending $getUserQuery request');
 
-  final resp =
-      await mediator.requests.send<User, GetUserByIdQuery>(getUserQuery);
+  final resp = await mediator.requests.send(getUserQuery);
 
   print('Got $GetUserByIdQuery response: $resp');
 
@@ -38,7 +37,7 @@ Future<void> main() async {
 
   print('Sending command $order66Command');
 
-  await mediator.requests.send<void, MyCommand>(order66Command);
+  await mediator.requests.send(order66Command);
 
   print('Command $order66Command completed');
 

--- a/lib/src/request/handler/request_handler_store.dart
+++ b/lib/src/request/handler/request_handler_store.dart
@@ -51,23 +51,26 @@ class RequestHandlerStore {
     _handlers.remove(TRequest);
   }
 
-  /// Returns the registered [RequestHandler]'s for [TRequest].
-  RequestHandler<TResponse, TRequest>
-      getHandlerFor<TResponse, TRequest extends Request<TResponse>>() {
-    final handler = _handlers[TRequest] ?? _handlerFactories[TRequest]?.call();
+  /// Returns the registered [RequestHandler]'s for [request].
+  RequestHandler getHandlerFor<TResponse extends Object?>(
+    Request<TResponse> request,
+  ) {
+    final requestType = request.runtimeType;
+    final handler =
+        _handlers[requestType] ?? _handlerFactories[requestType]?.call();
 
     assert(
       handler != null,
-      'getHandlerFor<$TResponse, $TRequest> did not have a registered handler. '
+      'getHandlerFor<$TResponse, $requestType> did not have a registered handler. '
       'Make sure to register the request handler first.',
     );
 
     assert(
-      handler is RequestHandler<TResponse, TRequest>,
+      handler is RequestHandler<TResponse, Request<TResponse>>,
       'The registered handler is of the wrong type got $handler but was '
-      'expecting a type of RequestHandler<$TResponse, $TRequest>',
+      'expecting a type of RequestHandler<$TResponse, $requestType>',
     );
 
-    return handler as RequestHandler<TResponse, TRequest>;
+    return handler!;
   }
 }

--- a/lib/src/request/pipeline/pipeline_configurator.dart
+++ b/lib/src/request/pipeline/pipeline_configurator.dart
@@ -1,4 +1,5 @@
 import 'package:dart_mediator/src/request/pipeline/pipeline_behavior.dart';
+import 'package:dart_mediator/src/request/request.dart';
 
 /// Factory to create a [PipelineBehavior].
 typedef PipelineBehaviorFactory<TRequest, TResponse>
@@ -9,7 +10,7 @@ abstract interface class PipelineConfigurator {
   ///
   /// When using a generic [PipelineBehavior] the [registerGeneric] should be
   /// used instead.
-  void register<TResponse extends Object?, TRequest extends Object>(
+  void register<TResponse extends Object?, TRequest extends Request<TResponse>>(
     PipelineBehavior<TResponse, TRequest> behavior,
   );
 
@@ -17,7 +18,8 @@ abstract interface class PipelineConfigurator {
   ///
   /// When using a generic [PipelineBehavior] the [registerGenericFactory] should
   /// be used instead.
-  void registerFactory<TResponse extends Object?, TRequest extends Object>(
+  void registerFactory<TResponse extends Object?,
+      TRequest extends Request<TResponse>>(
     PipelineBehaviorFactory<TResponse, TRequest> factory,
   );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_mediator
 description: >
   A simple yet highly configurable Mediator implementation
   that allows sending requests and publishing events.
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/MatthiWare/mediator.dart
 
 environment:

--- a/test/integration/choreography_test.dart
+++ b/test/integration/choreography_test.dart
@@ -44,8 +44,7 @@ void main() {
           ),
         );
 
-        final stock = await mediator.requests
-            .send<Map<String, int>, GetInventoryQuery>(GetInventoryQuery());
+        final stock = await mediator.requests.send(GetInventoryQuery());
 
         expect(stock, {
           'mouse': 8,

--- a/test/integration/external_test.dart
+++ b/test/integration/external_test.dart
@@ -1,0 +1,131 @@
+import 'package:dart_mediator/mediator.dart';
+import 'package:meta/meta.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+
+void main() {
+  group('External Integration', () {
+    late MockMediator mockMediator;
+    late MockEventManager mockEventManager;
+    late MockRequestManager mockRequestManager;
+    late ExternalClass externalClass;
+
+    setUp(() {
+      mockMediator = MockMediator();
+      mockEventManager = MockEventManager();
+      mockRequestManager = MockRequestManager();
+
+      when(() => mockMediator.events).thenReturn(mockEventManager);
+      when(() => mockMediator.requests).thenReturn(mockRequestManager);
+
+      externalClass = ExternalClass(mockMediator);
+    });
+
+    setUpAll(() {
+      registerFallbackValue(MockEventHandler<WorkCompletedEvent>());
+    });
+
+    group('subscribe', () {
+      test('should subscribe to event', () async {
+        // Arrange
+        final mockEventSubscriptionBuilder =
+            MockEventSubscriptionBuilder<WorkCompletedEvent>();
+
+        when(() => mockEventManager.on<WorkCompletedEvent>())
+            .thenReturn(mockEventSubscriptionBuilder);
+
+        when(() => mockEventSubscriptionBuilder.subscribe(any()))
+            .thenReturn(MockEventSubscription());
+
+        // Act
+        externalClass.subscribe();
+
+        // Assert
+        verify(() => mockEventSubscriptionBuilder
+            .subscribe(any<EventHandler<WorkCompletedEvent>>()));
+      });
+    });
+
+    group('doSomeWorkAsync', () {
+      test('should send query and dispatch event', () async {
+        // Arrange
+        const query = DoSomethingQuery(1);
+        const event = WorkCompletedEvent('1');
+
+        when(() => mockRequestManager.send(query)).thenAnswer((_) async => '1');
+        when(() => mockEventManager.dispatch(event)).thenAnswer((_) async {});
+
+        // Act
+        await externalClass.doSomeWorkAsync();
+
+        // Assert
+        verify(() => mockMediator.requests.send(query));
+        verify(() => mockMediator.events.dispatch(event));
+      });
+    });
+  });
+}
+
+@immutable
+class DoSomethingQuery implements Query<String> {
+  final int param;
+
+  const DoSomethingQuery(this.param);
+
+  @override
+  bool operator ==(Object other) {
+    return other is DoSomethingQuery && other.param == param;
+  }
+
+  @override
+  int get hashCode => param.hashCode;
+}
+
+class DoSomethingQueryHandler
+    implements QueryHandler<String, DoSomethingQuery> {
+  @override
+  Future<String> handle(DoSomethingQuery query) async {
+    return query.param.toString();
+  }
+}
+
+@immutable
+class WorkCompletedEvent implements DomainEvent {
+  final String result;
+
+  const WorkCompletedEvent(this.result);
+
+  @override
+  bool operator ==(Object other) {
+    return other is WorkCompletedEvent && other.result == result;
+  }
+
+  @override
+  int get hashCode => result.hashCode;
+}
+
+class WorkCompletedEventHandler implements EventHandler<WorkCompletedEvent> {
+  @override
+  Future<void> handle(WorkCompletedEvent event) async {
+    print(event.result);
+  }
+}
+
+class ExternalClass {
+  final Mediator mediator;
+
+  ExternalClass(this.mediator);
+
+  void subscribe() {
+    mediator.events
+        .on<WorkCompletedEvent>()
+        .subscribe(WorkCompletedEventHandler());
+  }
+
+  Future<void> doSomeWorkAsync() async {
+    final result = await mediator.requests.send(DoSomethingQuery(1));
+    mediator.events.dispatch(WorkCompletedEvent(result));
+  }
+}

--- a/test/integration/request_test.dart
+++ b/test/integration/request_test.dart
@@ -25,9 +25,7 @@ void main() {
       test('it handles the request', () async {
         mediator.requests.register(GetDataQueryHandler());
 
-        final data = await mediator.requests.send<String, GetDataQuery>(
-          GetDataQuery(123),
-        );
+        final data = await mediator.requests.send(GetDataQuery(123));
 
         expect(data, '123');
       });

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -7,6 +7,8 @@ class MockMediator extends Mock implements Mediator {}
 
 class MockRequestManager extends Mock implements RequestManager {}
 
+class MockEventManager extends Mock implements EventManager {}
+
 class MockDispatchStrategy extends Mock implements DispatchStrategy {}
 
 class MockEventHandlerStore extends Mock implements EventHandlerStore {}
@@ -28,5 +30,8 @@ class MockPipelineBehavior<Res, Req> extends Mock
     implements PipelineBehavior<Res, Req> {}
 
 class MockEventSubscription extends Mock implements EventSubscription {}
+
+class MockEventSubscriptionBuilder<T> extends Mock
+    implements EventSubscriptionBuilder<T> {}
 
 final throwsAssertionError = throwsA(TypeMatcher<AssertionError>());

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -35,9 +35,12 @@ class WrappingBehavior implements PipelineBehavior {
 class DelayBehavior implements PipelineBehavior {
   @override
   Future handle(request, RequestHandlerDelegate next) async {
-    print('$DelayBehavior: Before');
-    await Future.delayed(const Duration(milliseconds: 10));
-    await next();
-    print('$DelayBehavior: After');
+    try {
+      print('$DelayBehavior: Before');
+      await Future.delayed(const Duration(milliseconds: 10));
+      return await next();
+    } finally {
+      print('$DelayBehavior: After');
+    }
   }
 }

--- a/test/unit/request/pipeline_behavior/pipeline_behavior_store_test.dart
+++ b/test/unit/request/pipeline_behavior/pipeline_behavior_store_test.dart
@@ -6,9 +6,11 @@ import '../../../mocks.dart';
 void main() {
   group('PipelineBehaviorStore', () {
     late PipelineBehaviorStore pipelineBehaviorStore;
+    late MockRequest<int> mockRequest;
 
     setUp(() {
       pipelineBehaviorStore = PipelineBehaviorStore();
+      mockRequest = MockRequest();
     });
 
     group('register', () {
@@ -21,7 +23,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [mockBehavior],
         );
       });
@@ -37,7 +39,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [mockBehavior],
         );
       });
@@ -53,7 +55,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [mockBehavior],
         );
       });
@@ -70,7 +72,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [mockBehavior],
         );
       });
@@ -89,7 +91,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [],
         );
       });
@@ -102,7 +104,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [],
         );
       });
@@ -122,7 +124,7 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [],
         );
       });
@@ -137,17 +139,17 @@ void main() {
         );
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [],
         );
       });
     });
 
-    group('getPipelines{TResponse, TRequest}', () {
-      test('it returns the request handler', () {
+    group('getPipelines', () {
+      test('it returns the correct pipelines for the given request', () {
         final correctBehavior = MockPipelineBehavior<int, MockRequest<int>>();
         final incorrectBehavior =
-            MockPipelineBehavior<int, MockRequest<String>>();
+            MockPipelineBehavior<String, MockRequest<String>>();
         final logBehavior = MockPipelineBehavior();
 
         correctFactory() => correctBehavior;
@@ -162,7 +164,7 @@ void main() {
         pipelineBehaviorStore.registerFactory(incorrectFactory);
 
         expect(
-          pipelineBehaviorStore.getPipelines<int, MockRequest<int>>(),
+          pipelineBehaviorStore.getPipelines(mockRequest),
           [correctBehavior, correctBehavior, logBehavior, logBehavior],
         );
       });

--- a/test/unit/request/request_handler/request_handler_store_test.dart
+++ b/test/unit/request/request_handler/request_handler_store_test.dart
@@ -67,7 +67,7 @@ void main() {
     group('getHandlerFor{TResponse, TRequest}', () {
       test('it throws when the handler does not exist', () {
         expect(
-          () => requestHandlerStore.getHandlerFor<int, MockRequest<int>>(),
+          () => requestHandlerStore.getHandlerFor(MockRequest()),
           throwsAssertionError,
         );
       });
@@ -79,7 +79,7 @@ void main() {
         requestHandlerStore.register(handlerWithWrongTypes);
 
         expect(
-          () => requestHandlerStore.getHandlerFor<int, MockRequest<int>>(),
+          () => requestHandlerStore.getHandlerFor(MockRequest<int>()),
           throwsAssertionError,
         );
       });
@@ -89,8 +89,10 @@ void main() {
 
         requestHandlerStore.register(correctHandler);
 
+        final result = requestHandlerStore.getHandlerFor(MockRequest<int>());
+
         expect(
-          requestHandlerStore.getHandlerFor<int, MockRequest<int>>(),
+          result,
           correctHandler,
         );
       });
@@ -102,7 +104,7 @@ void main() {
         requestHandlerStore.registerFactory(correctHandlerFactory);
 
         expect(
-          requestHandlerStore.getHandlerFor<int, MockRequest<int>>(),
+          requestHandlerStore.getHandlerFor(MockRequest<int>()),
           mockHandler,
         );
       });

--- a/test/unit/request/requests_manager_test.dart
+++ b/test/unit/request/requests_manager_test.dart
@@ -88,15 +88,13 @@ void main() {
       test('it handles the request', () async {
         when(() => mockRequestHandler.handle(mockRequest)).thenReturn(output);
 
-        when(() => mockRequestHandlerStore
-                .getHandlerFor<String, MockRequest<String>>())
+        when(() => mockRequestHandlerStore.getHandlerFor(mockRequest))
             .thenReturn(mockRequestHandler);
 
-        when(() => mockPipelineBehaviorStore
-            .getPipelines<String, MockRequest<String>>()).thenReturn([]);
+        when(() => mockPipelineBehaviorStore.getPipelines(mockRequest))
+            .thenReturn([]);
 
-        final result = await requestsManager
-            .send<String, MockRequest<String>>(mockRequest);
+        final result = await requestsManager.send(mockRequest);
 
         verify(() => mockRequestHandler.handle(mockRequest));
 
@@ -115,8 +113,7 @@ void main() {
 
         when(() => mockRequestHandler.handle(mockRequest)).thenReturn(output);
 
-        when(() => mockRequestHandlerStore
-                .getHandlerFor<String, MockRequest<String>>())
+        when(() => mockRequestHandlerStore.getHandlerFor(mockRequest))
             .thenReturn(mockRequestHandler);
 
         when(() => mockBehavior.handle(mockRequest, captureAny()))
@@ -129,12 +126,10 @@ void main() {
           return handler();
         });
 
-        when(() => mockPipelineBehaviorStore
-                .getPipelines<String, MockRequest<String>>())
+        when(() => mockPipelineBehaviorStore.getPipelines(mockRequest))
             .thenReturn([mockBehavior]);
 
-        final result = await requestsManager
-            .send<String, MockRequest<String>>(mockRequest);
+        final result = await requestsManager.send(mockRequest);
 
         verify(() => mockRequestHandler.handle(mockRequest));
 
@@ -152,8 +147,7 @@ void main() {
 
         when(() => mockRequestHandler.handle(mockRequest)).thenReturn(output);
 
-        when(() => mockRequestHandlerStore
-                .getHandlerFor<String, MockRequest<String>>())
+        when(() => mockRequestHandlerStore.getHandlerFor(mockRequest))
             .thenReturn(mockRequestHandler);
 
         when(() => mockWrongBehavior.handle(mockRequest, captureAny()))
@@ -164,12 +158,11 @@ void main() {
           await handler(); // don't return on purpose
         });
 
-        when(() => mockPipelineBehaviorStore
-                .getPipelines<String, MockRequest<String>>())
+        when(() => mockPipelineBehaviorStore.getPipelines(mockRequest))
             .thenReturn([mockWrongBehavior]);
 
         await expectLater(
-          () => requestsManager.send<String, MockRequest<String>>(mockRequest),
+          () => requestsManager.send(mockRequest),
           throwsAssertionError,
         );
       });


### PR DESCRIPTION
This PR aims to improve the request typing by inferring the `Result` type based on the `Request<Result>`.

## Before
```dart
 final User user = await mediator.requests.send<User, GetUserByIdQuery>(getUserQuery);
```

## After
```dart
 final User user = await mediator.requests.send(getUserQuery);
```