### PR TITLE
Rework subscribe methods as extensions

### DIFF
--- a/lib/src/event/handler/event_handler.dart
+++ b/lib/src/event/handler/event_handler.dart
@@ -5,10 +5,20 @@ typedef EventHandlerFactory<TEvent> = EventHandler<TEvent> Function();
 
 /// Handler for [TEvent].
 abstract interface class EventHandler<TEvent> {
-  /// Function based event handler
+  /// Function based [EventHandler].
+  ///
+  /// Each event the underlying [handler] will be executed.
   const factory EventHandler.function(
     FutureOr<void> Function(TEvent event) handler,
   ) = _FunctionEventHandler;
+
+  /// Factory based [EventHandler]
+  ///
+  /// Each event the underlying [factory] will be instantiated and used
+  /// to handle the [TEvent].
+  const factory EventHandler.factory(
+    EventHandlerFactory<TEvent> factory,
+  ) = _FactoryEventHandler;
 
   /// Handles the given [event].
   FutureOr<void> handle(TEvent event);
@@ -21,4 +31,16 @@ class _FunctionEventHandler<T> implements EventHandler<T> {
 
   @override
   FutureOr<void> handle(T event) => handler(event);
+}
+
+class _FactoryEventHandler<T> implements EventHandler<T> {
+  final EventHandlerFactory<T> factory;
+
+  const _FactoryEventHandler(this.factory);
+
+  @override
+  FutureOr<void> handle(T event) {
+    final handler = factory();
+    return handler.handle(event);
+  }
 }

--- a/lib/src/event/handler/event_handler.dart
+++ b/lib/src/event/handler/event_handler.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 /// Factory to create a [EventHandler].
 typedef EventHandlerFactory<TEvent> = EventHandler<TEvent> Function();
 
@@ -24,6 +26,7 @@ abstract interface class EventHandler<TEvent> {
   FutureOr<void> handle(TEvent event);
 }
 
+@immutable
 class _FunctionEventHandler<T> implements EventHandler<T> {
   final FutureOr<void> Function(T event) handler;
 
@@ -31,8 +34,20 @@ class _FunctionEventHandler<T> implements EventHandler<T> {
 
   @override
   FutureOr<void> handle(T event) => handler(event);
+
+  @override
+  int get hashCode => Object.hash(runtimeType, handler);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FunctionEventHandler<T> &&
+            other.handler == handler);
+  }
 }
 
+@immutable
 class _FactoryEventHandler<T> implements EventHandler<T> {
   final EventHandlerFactory<T> factory;
 
@@ -42,5 +57,16 @@ class _FactoryEventHandler<T> implements EventHandler<T> {
   FutureOr<void> handle(T event) {
     final handler = factory();
     return handler.handle(event);
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, factory);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FactoryEventHandler<T> &&
+            other.factory == factory);
   }
 }

--- a/lib/src/event/handler/event_handler_store.dart
+++ b/lib/src/event/handler/event_handler_store.dart
@@ -1,8 +1,9 @@
+import 'dart:collection';
+
 import 'package:dart_mediator/src/event/handler/event_handler.dart';
 
 class EventHandlerStore {
   final _handlers = <Type, Set<EventHandler>>{};
-  final _handlerFactories = <Type, Set<EventHandlerFactory>>{};
 
   /// Registers the [handler] to a given [TEvent].
   void register<TEvent>(EventHandler<TEvent> handler) {
@@ -14,18 +15,6 @@ class EventHandlerStore {
     );
 
     handlers.add(handler);
-  }
-
-  /// Registers the [factory] to a given [TEvent].
-  void registerFactory<TEvent>(EventHandlerFactory<TEvent> factory) {
-    final factories = _getHandlerFactoriesFor<TEvent>();
-
-    assert(
-      !factories.contains(factory),
-      'registerFactory<$TEvent> was called with an already registered factory',
-    );
-
-    factories.add(factory);
   }
 
   /// Unregisters the given [handler].
@@ -40,28 +29,11 @@ class EventHandlerStore {
     handlers.remove(handler);
   }
 
-  /// Unregisters the given [factory].
-  void unregisterFactory<TEvent>(EventHandlerFactory<TEvent> factory) {
-    final factories = _getHandlerFactoriesFor<TEvent>();
-
-    assert(
-      factories.contains(factory),
-      'unregisterFactory<$TEvent> was called for a factory that was never registered',
-    );
-
-    factories.remove(factory);
-  }
-
   /// Returns all registered [EventHandler]'s for [TEvent].
   Set<EventHandler<TEvent>> getHandlersFor<TEvent>() {
     final handlers = _getHandlersFor<TEvent>();
-    final factories =
-        _getHandlerFactoriesFor<TEvent>().map((factory) => factory());
 
-    return {
-      ...handlers,
-      ...factories,
-    };
+    return UnmodifiableSetView(handlers);
   }
 
   Set<EventHandler<TEvent>> _getHandlersFor<TEvent>() {
@@ -71,14 +43,5 @@ class EventHandlerStore {
     ) as Set<EventHandler<TEvent>>;
 
     return handlers;
-  }
-
-  Set<EventHandlerFactory<TEvent>> _getHandlerFactoriesFor<TEvent>() {
-    final factories = _handlerFactories.putIfAbsent(
-      TEvent,
-      () => <EventHandlerFactory<TEvent>>{},
-    ) as Set<EventHandlerFactory<TEvent>>;
-
-    return factories;
   }
 }

--- a/lib/src/event/subscription_builder/event_subscription_builder.dart
+++ b/lib/src/event/subscription_builder/event_subscription_builder.dart
@@ -118,10 +118,12 @@ extension EventSubscriptionBuilderExtensions<T> on EventSubscriptionBuilder<T> {
     return subscribe(EventHandler.function(handler));
   }
 
-  /// Subscribes to the given [handler].
+  /// Subscribes to the given [factory].
   ///
   /// This finalizes the builder and applies all the steps
   /// before subscribing.
+  ///
+  /// This factory will be resolved into an actual [EventHandler] at request time.
   EventSubscription subscribeFactory(
     EventHandlerFactory<T> factory,
   ) {

--- a/lib/src/event/subscription_builder/event_subscription_builder.dart
+++ b/lib/src/event/subscription_builder/event_subscription_builder.dart
@@ -105,16 +105,9 @@ abstract class EventSubscriptionBuilder<T> {
   /// This finalizes the builder and applies all the steps
   /// before subscribing.
   EventSubscription subscribe(EventHandler<T> handler);
-
-  /// Subscribes to the given [factory].
-  ///
-  /// This finalizes the builder and applies all the steps
-  /// before subscribing.
-  EventSubscription subscribeFactory(EventHandlerFactory<T> factory);
 }
 
-extension EventSubscriptionBuilderFunctionExtension<T>
-    on EventSubscriptionBuilder<T> {
+extension EventSubscriptionBuilderExtensions<T> on EventSubscriptionBuilder<T> {
   /// Subscribes to the given [handler].
   ///
   /// This finalizes the builder and applies all the steps
@@ -123,6 +116,16 @@ extension EventSubscriptionBuilderFunctionExtension<T>
     FutureOr<void> Function(T event) handler,
   ) {
     return subscribe(EventHandler.function(handler));
+  }
+
+  /// Subscribes to the given [handler].
+  ///
+  /// This finalizes the builder and applies all the steps
+  /// before subscribing.
+  EventSubscription subscribeFactory(
+    EventHandlerFactory<T> factory,
+  ) {
+    return subscribe(EventHandler.factory(factory));
   }
 }
 
@@ -138,17 +141,6 @@ class _EventSubscriptionBuilder<T> extends EventSubscriptionBuilder<T> {
     );
 
     _store.register(handler);
-
-    return subscription;
-  }
-
-  @override
-  EventSubscription subscribeFactory(EventHandlerFactory<T> factory) {
-    final subscription = EventSubscription(
-      () => _store.unregisterFactory(factory),
-    );
-
-    _store.registerFactory(factory);
 
     return subscription;
   }
@@ -176,13 +168,5 @@ abstract class BaseEventSubscriptionBuilder<TInput, TOutput>
   @override
   EventSubscription subscribe(EventHandler<TOutput> handler) {
     return parent.subscribe(createHandler(handler));
-  }
-
-  @override
-  EventSubscription subscribeFactory(EventHandlerFactory<TOutput> factory) {
-    return parent.subscribeFactory(() {
-      final handler = factory();
-      return createHandler(handler);
-    });
   }
 }

--- a/lib/src/request/handler/request_handler.dart
+++ b/lib/src/request/handler/request_handler.dart
@@ -11,10 +11,15 @@ typedef RequestHandlerFactory<TResponse, TRequest extends Request<TResponse>>
 @internal
 abstract interface class RequestHandler<TResponse,
     TRequest extends Request<TResponse>> {
-  /// Function based request handler
+  /// Function based [RequestHandler].
   const factory RequestHandler.function(
     FutureOr<TResponse> Function(TRequest) handler,
   ) = _FunctionRequestHandler;
+
+  /// Factory based [RequestHandler].
+  const factory RequestHandler.factory(
+    RequestHandlerFactory<TResponse, TRequest> factory,
+  ) = _FactoryRequestHandler;
 
   /// Handles the given [request].
   FutureOr<TResponse> handle(TRequest request);
@@ -29,6 +34,7 @@ abstract interface class QueryHandler<TResponse extends Object,
         TQuery extends Query<TResponse>>
     implements RequestHandler<TResponse, TQuery> {}
 
+@immutable
 class _FunctionRequestHandler<TResponse, TRequest extends Request<TResponse>>
     implements RequestHandler<TResponse, TRequest> {
   final FutureOr<TResponse> Function(TRequest) handler;
@@ -37,4 +43,40 @@ class _FunctionRequestHandler<TResponse, TRequest extends Request<TResponse>>
 
   @override
   FutureOr<TResponse> handle(TRequest request) => handler(request);
+
+  @override
+  int get hashCode => Object.hash(runtimeType, handler);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FunctionRequestHandler<TResponse, TRequest> &&
+            other.handler == handler);
+  }
+}
+
+@immutable
+class _FactoryRequestHandler<TResponse, TRequest extends Request<TResponse>>
+    implements RequestHandler<TResponse, TRequest> {
+  final RequestHandlerFactory<TResponse, TRequest> factory;
+
+  const _FactoryRequestHandler(this.factory);
+
+  @override
+  FutureOr<TResponse> handle(TRequest request) {
+    final handler = factory();
+    return handler.handle(request);
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, factory);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FactoryRequestHandler<TResponse, TRequest> &&
+            other.factory == factory);
+  }
 }

--- a/lib/src/request/handler/request_handler_store.dart
+++ b/lib/src/request/handler/request_handler_store.dart
@@ -3,7 +3,6 @@ import 'package:dart_mediator/src/request/handler/request_handler.dart';
 
 class RequestHandlerStore {
   final _handlers = <Type, RequestHandler>{};
-  final _handlerFactories = <Type, RequestHandlerFactory>{};
 
   /// Registers the [handler] to a given [TRequest].
   void register<TResponse, TRequest extends Request<TResponse>>(
@@ -14,29 +13,7 @@ class RequestHandlerStore {
       'register<$TResponse, $TRequest> was called with an already registered handler',
     );
 
-    assert(
-      !_handlerFactories.containsKey(TRequest),
-      'register<$TRequest> was called with an already registered factory',
-    );
-
     _handlers[TRequest] = handler;
-  }
-
-  /// Registers the [factory] to a given [TRequest].
-  void registerFactory<TResponse, TRequest extends Request<TResponse>>(
-    RequestHandlerFactory<TResponse, TRequest> factory,
-  ) {
-    assert(
-      !_handlers.containsKey(TRequest),
-      'registerFactory<$TResponse, $TRequest> was called with an already registered handler',
-    );
-
-    assert(
-      !_handlerFactories.containsKey(TRequest),
-      'registerFactory<$TRequest> was called with an already registered factory',
-    );
-
-    _handlerFactories[TRequest] = factory;
   }
 
   /// Unregisters the given [handler].
@@ -56,8 +33,7 @@ class RequestHandlerStore {
     Request<TResponse> request,
   ) {
     final requestType = request.runtimeType;
-    final handler =
-        _handlers[requestType] ?? _handlerFactories[requestType]?.call();
+    final handler = _handlers[requestType];
 
     assert(
       handler != null,

--- a/lib/src/request/pipeline/pipeline_behavior.dart
+++ b/lib/src/request/pipeline/pipeline_behavior.dart
@@ -1,11 +1,30 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 /// Represents the continuation for the next task to execute in the pipeline.
 typedef RequestHandlerDelegate<TResponse> = FutureOr<TResponse> Function();
+
+/// Factory to create a [PipelineBehavior].
+typedef PipelineBehaviorFactory<TRequest, TResponse>
+    = PipelineBehavior<TRequest, TResponse> Function();
+
+typedef PipelineHandler<TResponse, TRequest> = FutureOr<TResponse> Function(
+    TRequest, RequestHandlerDelegate<TResponse>);
 
 /// Pipeline behavior to surround the inner handler.
 /// Implementations add additional behavior and await the next delegate.
 abstract interface class PipelineBehavior<TResponse, TRequest> {
+  /// Function based [PipelineBehavior].
+  const factory PipelineBehavior.function(
+    PipelineHandler<TResponse, TRequest> handler,
+  ) = _FunctionPipelineBehavior;
+
+  /// Factory based [PipelineBehavior].
+  const factory PipelineBehavior.factory(
+    PipelineBehaviorFactory<TResponse, TRequest> factory,
+  ) = _FactoryPipelineBehavior;
+
   /// Pipeline handler for [request].
   ///
   /// Perform any additional behavior and await the [next] delegate.
@@ -13,4 +32,58 @@ abstract interface class PipelineBehavior<TResponse, TRequest> {
     TRequest request,
     RequestHandlerDelegate<TResponse> next,
   );
+}
+
+@immutable
+class _FunctionPipelineBehavior<TResponse, TRequest>
+    implements PipelineBehavior<TResponse, TRequest> {
+  final PipelineHandler<TResponse, TRequest> handler;
+
+  const _FunctionPipelineBehavior(this.handler);
+
+  @override
+  FutureOr<TResponse> handle(
+    TRequest request,
+    RequestHandlerDelegate<TResponse> next,
+  ) =>
+      handler(request, next);
+
+  @override
+  int get hashCode => Object.hash(runtimeType, handler);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FunctionPipelineBehavior<TResponse, TRequest> &&
+            other.handler == handler);
+  }
+}
+
+@immutable
+class _FactoryPipelineBehavior<TResponse, TRequest>
+    implements PipelineBehavior<TResponse, TRequest> {
+  final PipelineBehaviorFactory<TResponse, TRequest> factory;
+
+  const _FactoryPipelineBehavior(this.factory);
+
+  @override
+  FutureOr<TResponse> handle(
+    TRequest request,
+    RequestHandlerDelegate<TResponse> next,
+  ) {
+    final behavior = factory();
+    return behavior.handle(request, next);
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, factory);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _FactoryPipelineBehavior<TResponse, TRequest> &&
+            other.factory == factory);
+  }
 }

--- a/lib/src/request/pipeline/pipeline_configurator.dart
+++ b/lib/src/request/pipeline/pipeline_configurator.dart
@@ -1,9 +1,4 @@
-import 'package:dart_mediator/src/request/pipeline/pipeline_behavior.dart';
-import 'package:dart_mediator/src/request/request.dart';
-
-/// Factory to create a [PipelineBehavior].
-typedef PipelineBehaviorFactory<TRequest, TResponse>
-    = PipelineBehavior<TRequest, TResponse> Function();
+import 'package:dart_mediator/request_manager.dart';
 
 abstract interface class PipelineConfigurator {
   /// Registers the [behavior].
@@ -14,15 +9,6 @@ abstract interface class PipelineConfigurator {
     PipelineBehavior<TResponse, TRequest> behavior,
   );
 
-  /// Registers the [factory].
-  ///
-  /// When using a generic [PipelineBehavior] the [registerGenericFactory] should
-  /// be used instead.
-  void registerFactory<TResponse extends Object?,
-      TRequest extends Request<TResponse>>(
-    PipelineBehaviorFactory<TResponse, TRequest> factory,
-  );
-
   /// Registers the generic [behavior].
   ///
   /// Note, this should only be used when [register] is not possible.
@@ -30,16 +16,65 @@ abstract interface class PipelineConfigurator {
     PipelineBehavior behavior,
   );
 
-  /// Registers the generic [factory].
-  ///
-  /// Note, this should only be used when [registerFactory] is not possible.
-  void registerGenericFactory(
-    PipelineBehaviorFactory factory,
+  /// Unregisters the given [behavior].
+  void unregister<TResponse extends Object?,
+      TRequest extends Request<TResponse>>(
+    PipelineBehavior<TResponse, TRequest> behavior,
   );
 
-  /// Unregisters the given [behavior].
-  void unregister(PipelineBehavior behavior);
+  /// Unregisters the generic [behavior].
+  void unregisterGeneric(PipelineBehavior behavior);
+}
 
-  /// Unregisters the given [factory].
-  void unregisterFactory(PipelineBehaviorFactory factory);
+extension PipelineConfiguratorExtensions on PipelineConfigurator {
+  /// Registers the given [handler].
+  ///
+  /// This will create a function based [PipelineBehavior].
+  ///
+  /// See [PipelineBehavior.function].
+  void registerFunction<TResponse extends Object?,
+      TRequest extends Request<TResponse>>(
+    PipelineHandler<TResponse, TRequest> handler,
+  ) {
+    register(PipelineBehavior.function(handler));
+  }
+
+  /// Registers the given [factory].
+  ///
+  /// This will create a factory based [PipelineBehavior]. This factory will be
+  /// resolved into an actual [PipelineBehavior] at request time.
+  ///
+  /// See [PipelineBehavior.factory].
+  void registerFactory<TResponse extends Object?,
+      TRequest extends Request<TResponse>>(
+    PipelineBehaviorFactory<TResponse, TRequest> factory,
+  ) {
+    register(PipelineBehavior.factory(factory));
+  }
+
+  /// Registers the given generic [handler].
+  ///
+  /// This will create a function based [PipelineBehavior].
+  ///
+  ///
+  /// See [registerGeneric].
+  /// See [PipelineBehavior.function].
+  void registerGenericFunction(
+    PipelineHandler handler,
+  ) {
+    registerGeneric(PipelineBehavior.function(handler));
+  }
+
+  /// Registers the given generic [factory].
+  ///
+  /// This will create a factory based [PipelineBehavior]. This factory will be
+  /// resolved into an actual [PipelineBehavior] at request time.
+  ///
+  /// See [registerGeneric].
+  /// See [PipelineBehavior.factory].
+  void registerGenericFactory(
+    PipelineBehaviorFactory factory,
+  ) {
+    registerGeneric(PipelineBehavior.factory(factory));
+  }
 }

--- a/lib/src/request/request_manager.dart
+++ b/lib/src/request/request_manager.dart
@@ -43,13 +43,6 @@ class RequestManager {
     _requestHandlerStore.register(handler);
   }
 
-  /// Registers the request [factory] for the given [TRequest].
-  void registerFactory<TResponse, TRequest extends Request<TResponse>>(
-    RequestHandlerFactory<TResponse, TRequest> factory,
-  ) {
-    _requestHandlerStore.registerFactory(factory);
-  }
-
   /// Sends a [request] to a single [RequestHandler].
   ///
   /// Make sure the [RequestHandler] is [register]ed before calling this method.
@@ -98,5 +91,17 @@ extension RequestManagerExtensions on RequestManager {
     FutureOr<TResponse> Function(TRequest) handler,
   ) {
     register(RequestHandler.function(handler));
+  }
+
+  /// Registers the given [factory].
+  ///
+  /// This will create a factory based request handler. This factory will be
+  /// resolved into an actual [RequestHandler] at request time.
+  ///
+  /// See [RequestHandler.factory].
+  void registerFactory<TResponse, TRequest extends Request<TResponse>>(
+    RequestHandlerFactory<TResponse, TRequest> factory,
+  ) {
+    register(RequestHandler.factory(factory));
   }
 }

--- a/test/integration/event_test.dart
+++ b/test/integration/event_test.dart
@@ -98,6 +98,13 @@ void main() {
             .where((event) => event > 10)
             .subscribeFactory(factory);
 
+        final eventHandler = _CollectingEventSubscriber();
+
+        mediator.events
+            .on<DomainIntEvent>()
+            .where((event) => event.count > 10)
+            .subscribe(eventHandler);
+
         final events = Iterable.generate(20, (index) => index);
 
         for (final event in events.skip(10)) {
@@ -109,7 +116,19 @@ void main() {
         expect(handler1, expected);
         expect(handler2, expected);
         expect(handler3, expected);
+        expect(eventHandler.events, expected);
       });
     });
   });
+}
+
+class _CollectingEventSubscriber implements EventHandler<DomainIntEvent> {
+  final events = <int>[];
+
+  @override
+  void handle(DomainIntEvent event) {
+    if (event.count > 10) {
+      events.add(event.count);
+    }
+  }
 }

--- a/test/integration/request_test.dart
+++ b/test/integration/request_test.dart
@@ -35,7 +35,7 @@ void main() {
         final behavior = WrappingBehavior(
           () {
             print('pipeline callback');
-            return pipeline = true;
+            pipeline = true;
           },
         );
 

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:dart_mediator/contracts.dart';
 import 'package:dart_mediator/src/request/pipeline/pipeline_behavior.dart';
+import 'package:meta/meta.dart';
 
+@immutable
 class DomainIntEvent implements DomainEvent {
   final int count;
 
@@ -13,16 +15,39 @@ class DomainIntEvent implements DomainEvent {
   }) {
     return DomainIntEvent(count);
   }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, count);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is DomainIntEvent &&
+            other.count == count);
+  }
 }
 
+@immutable
 class GetDataQuery implements Query<String> {
   final int id;
 
   const GetDataQuery(this.id);
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is GetDataQuery &&
+            other.id == id);
+  }
 }
 
 class WrappingBehavior implements PipelineBehavior {
-  final Function() callback;
+  final void Function() callback;
   WrappingBehavior(this.callback);
 
   @override

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -46,17 +46,6 @@ class GetDataQuery implements Query<String> {
   }
 }
 
-class WrappingBehavior implements PipelineBehavior {
-  final void Function() callback;
-  WrappingBehavior(this.callback);
-
-  @override
-  FutureOr handle(request, RequestHandlerDelegate next) {
-    callback();
-    return next();
-  }
-}
-
 class DelayBehavior implements PipelineBehavior {
   @override
   Future handle(request, RequestHandlerDelegate next) async {

--- a/test/unit/event/dispatch/concurrent_dispatch_test.dart
+++ b/test/unit/event/dispatch/concurrent_dispatch_test.dart
@@ -71,9 +71,12 @@ void main() {
           count = newCount;
         }
 
-        final handlerA = EventHandler<DomainIntEvent>.function(handle);
-        final handlerB = EventHandler<DomainIntEvent>.function(handle);
-        final handlerC = EventHandler<DomainIntEvent>.function(handle);
+        final handlerA =
+            EventHandler<DomainIntEvent>.function((e) => handle(e));
+        final handlerB =
+            EventHandler<DomainIntEvent>.function((e) => handle(e));
+        final handlerC =
+            EventHandler<DomainIntEvent>.function((e) => handle(e));
 
         final handlers = {handlerA, handlerB, handlerC};
         const event = DomainIntEvent(1);

--- a/test/unit/event/dispatch/sequential_dispatch_test.dart
+++ b/test/unit/event/dispatch/sequential_dispatch_test.dart
@@ -71,9 +71,12 @@ void main() {
           count = newCount;
         }
 
-        final handlerA = EventHandler<DomainIntEvent>.function(handle);
-        final handlerB = EventHandler<DomainIntEvent>.function(handle);
-        final handlerC = EventHandler<DomainIntEvent>.function(handle);
+        final handlerA =
+            EventHandler<DomainIntEvent>.function((e) => handle(e));
+        final handlerB =
+            EventHandler<DomainIntEvent>.function((e) => handle(e));
+        final handlerC =
+            EventHandler<DomainIntEvent>.function((e) => handle(e));
 
         final handlers = {handlerA, handlerB, handlerC};
         const event = DomainIntEvent(1);

--- a/test/unit/event/event_handler/event_handler_store_test.dart
+++ b/test/unit/event/event_handler/event_handler_store_test.dart
@@ -30,26 +30,6 @@ void main() {
       });
     });
 
-    group('registerFactory', () {
-      test('it registers the factory', () {
-        expect(
-          () =>
-              eventHandlerStore.registerFactory(() => MockEventHandler<int>()),
-          returnsNormally,
-        );
-      });
-
-      test('it throws when registering the same handler multiple times', () {
-        MockEventHandler<int> factory() => MockEventHandler<int>();
-
-        eventHandlerStore.registerFactory(factory);
-        expect(
-          () => eventHandlerStore.registerFactory(factory),
-          throwsAssertionError,
-        );
-      });
-    });
-
     group('unregister', () {
       test('it unregisters the event handler', () {
         final handler = MockEventHandler<int>();
@@ -75,43 +55,15 @@ void main() {
       });
     });
 
-    group('unregisterFactory', () {
-      test('it unregisters the factory', () {
-        MockEventHandler<int> factory() => MockEventHandler<int>();
-
-        eventHandlerStore.registerFactory(factory);
-
-        expect(
-          () => eventHandlerStore.unregisterFactory(factory),
-          returnsNormally,
-        );
-      });
-
-      test('it throws when unregistering the same factory multiple times', () {
-        MockEventHandler<int> factory() => MockEventHandler<int>();
-
-        eventHandlerStore.registerFactory(factory);
-        eventHandlerStore.unregisterFactory(factory);
-
-        expect(
-          () => eventHandlerStore.unregisterFactory(factory),
-          throwsAssertionError,
-        );
-      });
-    });
-
     group('getHandlersFor{TEvent}', () {
       test('it returns the registered handlers', () {
         final handler = MockEventHandler<int>();
-        final factoryHandler = MockEventHandler<int>();
-        MockEventHandler<int> factory() => factoryHandler;
 
         eventHandlerStore.register(handler);
-        eventHandlerStore.registerFactory(factory);
 
         expect(
           eventHandlerStore.getHandlersFor<int>(),
-          {handler, factoryHandler},
+          {handler},
         );
       });
     });

--- a/test/unit/event/event_handler/event_handler_test.dart
+++ b/test/unit/event/event_handler/event_handler_test.dart
@@ -1,0 +1,60 @@
+import 'package:dart_mediator/event_manager.dart';
+import 'package:dart_mediator/src/event/handler/event_handler.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../../mocks.dart';
+
+void main() {
+  group('EventHandler', () {
+    group('function', () {
+      group('handle', () {
+        test('it handles the event', () {
+          var handled = false;
+          final handler = EventHandler<int>.function((event) {
+            handled = true;
+          });
+
+          handler.handle(123);
+
+          expect(handled, isTrue);
+        });
+      });
+
+      test('is immutable', () {
+        void handler(int a) {}
+
+        final a = EventHandler.function(handler);
+        final b = EventHandler.function(handler);
+
+        expect(a, b);
+        expect(a == b, isTrue);
+        expect(a.hashCode == b.hashCode, isTrue);
+      });
+    });
+
+    group('factory', () {
+      group('handle', () {
+        test('it handles the event', () {
+          final mockEventHandler = MockEventHandler<int>();
+          final handler = EventHandler<int>.factory(() => mockEventHandler);
+
+          handler.handle(123);
+
+          verify(() => mockEventHandler.handle(123));
+        });
+      });
+
+      test('is immutable', () {
+        EventHandler<int> factory() => MockEventHandler();
+
+        final a = EventHandler.factory(factory);
+        final b = EventHandler.factory(factory);
+
+        expect(a, b);
+        expect(a == b, isTrue);
+        expect(a.hashCode == b.hashCode, isTrue);
+      });
+    });
+  });
+}

--- a/test/unit/event/event_subscription_builder/event_subscription_builder_test.dart
+++ b/test/unit/event/event_subscription_builder/event_subscription_builder_test.dart
@@ -94,15 +94,15 @@ void main() {
     });
 
     group('subscribeFactory', () {
-      final mockHandler = MockEventHandler<int>();
+      EventHandler<int> handlerFactory() => MockEventHandler();
 
-      EventHandler<int> handlerFactory() => mockHandler;
+      final factoryHandler = EventHandler.factory(handlerFactory);
 
       test('it subscribes the handler', () {
         EventSubscriptionBuilder<int>.create(mockEventHandlerStore)
             .subscribeFactory(handlerFactory);
 
-        verify(() => mockEventHandlerStore.register(mockHandler));
+        verify(() => mockEventHandlerStore.register(factoryHandler));
       });
 
       test('it return a subscription', () {
@@ -124,7 +124,7 @@ void main() {
 
         subscription.cancel();
 
-        verify(() => mockEventHandlerStore.unregister(mockHandler));
+        verify(() => mockEventHandlerStore.unregister(factoryHandler));
       });
     });
   });

--- a/test/unit/event/event_subscription_builder/event_subscription_builder_test.dart
+++ b/test/unit/event/event_subscription_builder/event_subscription_builder_test.dart
@@ -94,14 +94,15 @@ void main() {
     });
 
     group('subscribeFactory', () {
-      EventHandler<int> handlerFactory() =>
-          EventHandler<int>.function((event) {});
+      final mockHandler = MockEventHandler<int>();
+
+      EventHandler<int> handlerFactory() => mockHandler;
 
       test('it subscribes the handler', () {
         EventSubscriptionBuilder<int>.create(mockEventHandlerStore)
             .subscribeFactory(handlerFactory);
 
-        verify(() => mockEventHandlerStore.registerFactory(handlerFactory));
+        verify(() => mockEventHandlerStore.register(mockHandler));
       });
 
       test('it return a subscription', () {
@@ -123,7 +124,7 @@ void main() {
 
         subscription.cancel();
 
-        verify(() => mockEventHandlerStore.unregisterFactory(handlerFactory));
+        verify(() => mockEventHandlerStore.unregister(mockHandler));
       });
     });
   });

--- a/test/unit/request/pipeline_behavior/pipeline_behavior_test.dart
+++ b/test/unit/request/pipeline_behavior/pipeline_behavior_test.dart
@@ -1,0 +1,77 @@
+import 'dart:async';
+
+import 'package:dart_mediator/request_manager.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../../mocks.dart';
+
+void main() {
+  group('RequestHandler', () {
+    group('function', () {
+      group('handle', () {
+        test('it handles the request', () {
+          var handled = false;
+          final mockRequest = MockRequest<int>();
+          final handler =
+              PipelineBehavior<int, MockRequest<int>>.function((req, next) {
+            handled = true;
+            return next();
+          });
+
+          expect(handler.handle(mockRequest, () => 123), 123);
+          expect(handled, isTrue);
+        });
+      });
+
+      test('is immutable', () {
+        FutureOr<int> handler(
+          Request<String> req,
+          RequestHandlerDelegate<int> next,
+        ) {
+          return next();
+        }
+
+        final a = PipelineBehavior.function(handler);
+        final b = PipelineBehavior.function(handler);
+
+        expect(a, b);
+        expect(a == b, isTrue);
+        expect(a.hashCode == b.hashCode, isTrue);
+      });
+    });
+
+    group('factory', () {
+      group('handle', () {
+        test('it handles the request', () {
+          final mockPipeline = MockPipelineBehavior<int, MockRequest<int>>();
+          PipelineBehavior<int, MockRequest<int>> factory() => mockPipeline;
+
+          final handler =
+              PipelineBehavior<int, MockRequest<int>>.factory(factory);
+
+          int next() => 123;
+          final request = MockRequest<int>();
+
+          when(() => mockPipeline.handle(request, next)).thenReturn(123);
+
+          handler.handle(request, next);
+
+          verify(() => mockPipeline.handle(request, next));
+        });
+      });
+
+      test('is immutable', () {
+        PipelineBehavior<int, MockRequest<int>> factory() =>
+            MockPipelineBehavior();
+
+        final a = PipelineBehavior.factory(factory);
+        final b = PipelineBehavior.factory(factory);
+
+        expect(a, b);
+        expect(a == b, isTrue);
+        expect(a.hashCode == b.hashCode, isTrue);
+      });
+    });
+  });
+}

--- a/test/unit/request/request_handler/request_handler_store_test.dart
+++ b/test/unit/request/request_handler/request_handler_store_test.dart
@@ -1,4 +1,3 @@
-import 'package:dart_mediator/src/request/handler/request_handler.dart';
 import 'package:dart_mediator/src/request/handler/request_handler_store.dart';
 import 'package:test/test.dart';
 
@@ -7,9 +6,6 @@ import '../../../mocks.dart';
 void main() {
   group('RequestHandlerStore', () {
     late RequestHandlerStore requestHandlerStore;
-
-    RequestHandler<int, MockRequest<int>> handlerFactory() =>
-        MockRequestHandler<int, MockRequest<int>>();
 
     final mockRequestHandler = MockRequestHandler<int, MockRequest<int>>();
 
@@ -32,48 +28,12 @@ void main() {
           throwsAssertionError,
         );
       });
-
-      test('it throws when a factory for this type was already registered', () {
-        requestHandlerStore.registerFactory(handlerFactory);
-
-        expect(
-          () => requestHandlerStore.register(mockRequestHandler),
-          throwsAssertionError,
-        );
-      });
-    });
-
-    group('registerFactory', () {
-      test('it registers the handler', () {
-        expect(
-          () => requestHandlerStore.registerFactory(handlerFactory),
-          returnsNormally,
-        );
-      });
-
-      test('it throws when registering the same factory multiple times', () {
-        requestHandlerStore.registerFactory(handlerFactory);
-
-        expect(
-          () => requestHandlerStore.registerFactory(handlerFactory),
-          throwsAssertionError,
-        );
-      });
-
-      test('it throws when a handler for this type was already registered', () {
-        requestHandlerStore.register(mockRequestHandler);
-
-        expect(
-          () => requestHandlerStore.registerFactory(handlerFactory),
-          throwsAssertionError,
-        );
-      });
     });
 
     group('unregister', () {
       final mockRequestHandler = MockRequestHandler<int, MockRequest<int>>();
 
-      test('it unsubscribes to the event', () {
+      test('it unregisters the handler', () {
         requestHandlerStore.register(mockRequestHandler);
 
         expect(
@@ -123,19 +83,6 @@ void main() {
         expect(
           result,
           correctHandler,
-        );
-      });
-
-      test('it returns the request handler factory', () {
-        final mockHandler = MockRequestHandler<int, MockRequest<int>>();
-        MockRequestHandler<int, MockRequest<int>> correctHandlerFactory() =>
-            mockHandler;
-
-        requestHandlerStore.registerFactory(correctHandlerFactory);
-
-        expect(
-          requestHandlerStore.getHandlerFor(MockRequest<int>()),
-          mockHandler,
         );
       });
     });

--- a/test/unit/request/request_handler/request_handler_test.dart
+++ b/test/unit/request/request_handler/request_handler_test.dart
@@ -1,23 +1,66 @@
 import 'package:dart_mediator/src/request/handler/request_handler.dart';
+import 'package:dart_mediator/src/request/request.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../../../mocks.dart';
 
 void main() {
   group('RequestHandler', () {
-    setUp(() {});
+    group('function', () {
+      group('handle', () {
+        test('it handles the request', () {
+          var handled = false;
+          final mockRequest = MockRequest<int>();
+          final handler = RequestHandler<int, MockRequest<int>>.function((req) {
+            handled = true;
+            return 123;
+          });
 
-    group('handle', () {
-      test('it handles the request', () {
-        var handled = false;
-        final mockRequest = MockRequest<int>();
-        final handler = RequestHandler<int, MockRequest<int>>.function((req) {
-          handled = true;
-          return 123;
+          expect(handler.handle(mockRequest), 123);
+          expect(handled, isTrue);
         });
+      });
 
-        expect(handler.handle(mockRequest), 123);
-        expect(handled, isTrue);
+      test('is immutable', () {
+        int handle(MockRequest<int> req) => 123;
+
+        final a = RequestHandler.function(handle);
+        final b = RequestHandler.function(handle);
+
+        expect(a, b);
+        expect(a == b, isTrue);
+        expect(a.hashCode == b.hashCode, isTrue);
+      });
+    });
+
+    group('factory', () {
+      group('handle', () {
+        test('it handles the request', () {
+          final mockRequest = MockRequest<int>();
+          final mockHandler = MockRequestHandler<int, MockRequest<int>>();
+
+          when(() => mockHandler.handle(mockRequest)).thenReturn(123);
+
+          MockRequestHandler<int, MockRequest<int>> factory() => mockHandler;
+
+          final handler = RequestHandler.factory(factory);
+
+          expect(handler.handle(mockRequest), 123);
+
+          verify(() => mockHandler.handle(mockRequest));
+        });
+      });
+
+      test('is immutable', () {
+        RequestHandler<int, Request<int>> factory() => MockRequestHandler();
+
+        final a = RequestHandler.factory(factory);
+        final b = RequestHandler.factory(factory);
+
+        expect(a, b);
+        expect(a == b, isTrue);
+        expect(a.hashCode == b.hashCode, isTrue);
       });
     });
   });

--- a/test/unit/request/requests_manager_test.dart
+++ b/test/unit/request/requests_manager_test.dart
@@ -1,3 +1,4 @@
+import 'package:dart_mediator/src/request/handler/request_handler.dart';
 import 'package:dart_mediator/src/request/pipeline/pipeline_behavior.dart';
 import 'package:dart_mediator/src/request/request_manager.dart';
 import 'package:mocktail/mocktail.dart';
@@ -50,29 +51,34 @@ void main() {
 
     group('registerFactory', () {
       test('it registers the handler', () {
-        MockRequestHandler<String, MockRequest<String>>
-            mockRequestHandlerFactory() =>
-                MockRequestHandler<String, MockRequest<String>>();
+        MockRequestHandler<String, MockRequest<String>> factory() =>
+            MockRequestHandler();
 
         requestsManager.registerFactory<String, MockRequest<String>>(
-          mockRequestHandlerFactory,
+          factory,
         );
 
         verify(
-          () => mockRequestHandlerStore
-              .registerFactory(mockRequestHandlerFactory),
+          () => mockRequestHandlerStore.register<String, MockRequest<String>>(
+            RequestHandler.factory(factory),
+          ),
         );
       });
     });
 
     group('registerFunction', () {
       test('it registers the handler', () {
-        requestsManager.registerFunction<String, MockRequest<String>>(
-          (request) async => '123',
-        );
+        String handle(MockRequest<String> req) {
+          return '123';
+        }
 
-        verify(() => mockRequestHandlerStore
-            .register<String, MockRequest<String>>(any()));
+        requestsManager.registerFunction<String, MockRequest<String>>(handle);
+
+        verify(
+          () => mockRequestHandlerStore.register<String, MockRequest<String>>(
+            RequestHandler.function(handle),
+          ),
+        );
       });
     });
 


### PR DESCRIPTION
Removed `registerFactory` methods in favor of extension methods that wrap the factory and call the normal `register` method.
