### PR TITLE
Add unregister method for requests

### DIFF
--- a/lib/src/request/request_manager.dart
+++ b/lib/src/request/request_manager.dart
@@ -43,6 +43,13 @@ class RequestManager {
     _requestHandlerStore.register(handler);
   }
 
+  /// Registers the request [handler] for the given [TRequest].
+  void unregister<TResponse, TRequest extends Request<TResponse>>(
+    RequestHandler<TResponse, TRequest> handler,
+  ) {
+    _requestHandlerStore.unregister(handler);
+  }
+
   /// Sends a [request] to a single [RequestHandler].
   ///
   /// Make sure the [RequestHandler] is [register]ed before calling this method.

--- a/test/integration/request_test.dart
+++ b/test/integration/request_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dart_mediator/mediator.dart';
 import 'package:test/test.dart';
 
+import '../mocks.dart';
 import '../test_data.dart';
 
 class GetDataQueryHandler implements QueryHandler<String, GetDataQuery> {
@@ -22,6 +23,18 @@ void main() {
     });
 
     group('requests', () {
+      test('it unregisters the request handler', () async {
+        final handler = GetDataQueryHandler();
+
+        mediator.requests.register(handler);
+        mediator.requests.unregister(handler);
+
+        await expectLater(
+          mediator.requests.send(const GetDataQuery(123)),
+          throwsAssertionError,
+        );
+      });
+
       test('it handles the normal request', () async {
         mediator.requests.register(GetDataQueryHandler());
 

--- a/test/unit/request/requests_manager_test.dart
+++ b/test/unit/request/requests_manager_test.dart
@@ -82,6 +82,17 @@ void main() {
       });
     });
 
+    group('unregister', () {
+      test('it unregisters the handler', () {
+        final mockRequestHandler =
+            MockRequestHandler<String, MockRequest<String>>();
+
+        requestsManager.unregister(mockRequestHandler);
+
+        verify(() => mockRequestHandlerStore.unregister(mockRequestHandler));
+      });
+    });
+
     group('send{TResponse, TRequest}', () {
       const output = '123';
       late MockRequest<String> mockRequest;


### PR DESCRIPTION
Adds `unregister` on `RequestManager`.