### PR TITLE
Add `sendStream` method

### DIFF
--- a/lib/src/request/request_manager.dart
+++ b/lib/src/request/request_manager.dart
@@ -122,3 +122,20 @@ extension RequestManagerExtensions on RequestManager {
     register(RequestHandler.factory(factory));
   }
 }
+
+extension RequestManagerStreamExtensions on RequestManager {
+  /// Sends a [requestStream] to a single [RequestHandler].
+  ///
+  /// Make sure the [RequestHandler] is [register]ed before calling this method.
+  ///
+  /// This request can be wrapped by [PipelineBehavior]'s see [pipeline].
+  ///
+  /// This will return [TResponse].
+  Stream<TResponse> sendStream<TResponse extends Object?>(
+    Stream<Request<TResponse>> requestStream,
+  ) async* {
+    await for (final request in requestStream) {
+      yield await send(request);
+    }
+  }
+}

--- a/test/unit/request/requests_manager_test.dart
+++ b/test/unit/request/requests_manager_test.dart
@@ -225,5 +225,38 @@ void main() {
         );
       });
     });
+
+    group('sendStream', () {
+      const output = '123';
+      late MockRequest<String> mockRequest;
+      late MockRequestHandler<String, MockRequest<String>> mockRequestHandler;
+
+      setUp(() {
+        mockRequest = MockRequest<String>();
+        mockRequestHandler = MockRequestHandler<String, MockRequest<String>>();
+      });
+
+      test('it handles the request', () async {
+        when(() => mockRequestHandler.handle(mockRequest)).thenReturn(output);
+
+        when(() => mockRequestHandlerStore.getHandlerFor(mockRequest))
+            .thenReturn(mockRequestHandler);
+
+        when(() => mockPipelineBehaviorStore.getPipelines(mockRequest))
+            .thenReturn({});
+
+        final inputStream = Stream.value(mockRequest);
+
+        final result = await requestsManager.sendStream(inputStream).toList();
+
+        verify(() => mockRequestHandler.handle(mockRequest));
+
+        expect(
+          result.first,
+          output,
+          reason: 'Should return the handler response',
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
This PR adds `RequestManager.sendStream` extension method.