### PR TITLE
Fix events not using correct type for dispatching

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -149,9 +149,9 @@ class LoggingBehavior implements PipelineBehavior {
 
 class LoggingEventObserver implements EventObserver {
   @override
-  void onDispatch<TEvent extends DomainEvent>(
+  void onDispatch<TEvent>(
     TEvent event,
-    Set<EventHandler<TEvent>> handlers,
+    Set<EventHandler> handlers,
   ) {
     print(
       '[LoggingEventObserver] onDispatch "$event" with ${handlers.length} handlers',
@@ -159,9 +159,9 @@ class LoggingEventObserver implements EventObserver {
   }
 
   @override
-  void onError<TEvent extends DomainEvent>(
+  void onError<TEvent>(
     TEvent event,
-    EventHandler<TEvent> handler,
+    EventHandler handler,
     Object error,
     StackTrace stackTrace,
   ) {
@@ -169,9 +169,9 @@ class LoggingEventObserver implements EventObserver {
   }
 
   @override
-  void onHandled<TEvent extends DomainEvent>(
+  void onHandled<TEvent>(
     TEvent event,
-    EventHandler<TEvent> handler,
+    EventHandler handler,
   ) {
     print('[LoggingEventObserver] onHandled $event handled by $handler');
   }

--- a/lib/src/event/dispatch/concurrent_strategy.dart
+++ b/lib/src/event/dispatch/concurrent_strategy.dart
@@ -1,5 +1,4 @@
 import 'package:dart_mediator/src/event/dispatch/dispatch_strategy.dart';
-import 'package:dart_mediator/src/event/event.dart';
 import 'package:dart_mediator/src/event/handler/event_handler.dart';
 import 'package:dart_mediator/src/event/observer/event_observer.dart';
 
@@ -12,7 +11,7 @@ class ConcurrentDispatchStrategy implements DispatchStrategy {
   const ConcurrentDispatchStrategy();
 
   @override
-  Future<void> execute<TEvent extends DomainEvent>(
+  Future<void> execute<TEvent>(
     Set<EventHandler<TEvent>> handlers,
     TEvent event,
     List<EventObserver> observers,

--- a/lib/src/event/dispatch/dispatch_strategy.dart
+++ b/lib/src/event/dispatch/dispatch_strategy.dart
@@ -1,4 +1,3 @@
-import 'package:dart_mediator/src/event/event.dart';
 import 'package:dart_mediator/src/event/handler/event_handler.dart';
 import 'package:dart_mediator/src/event/dispatch/concurrent_strategy.dart';
 import 'package:dart_mediator/src/event/dispatch/sequential_strategy.dart';
@@ -18,7 +17,7 @@ abstract interface class DispatchStrategy {
 
   /// Executes the given strategy by applying the [event] to the given
   /// [handlers].
-  Future<void> execute<TEvent extends DomainEvent>(
+  Future<void> execute<TEvent>(
     Set<EventHandler<TEvent>> handlers,
     TEvent event,
     List<EventObserver> observers,

--- a/lib/src/event/dispatch/sequential_strategy.dart
+++ b/lib/src/event/dispatch/sequential_strategy.dart
@@ -1,5 +1,4 @@
 import 'package:dart_mediator/src/event/dispatch/dispatch_strategy.dart';
-import 'package:dart_mediator/src/event/event.dart';
 import 'package:dart_mediator/src/event/handler/event_handler.dart';
 import 'package:dart_mediator/src/event/observer/event_observer.dart';
 
@@ -14,7 +13,7 @@ class SequentialDispatchStrategy implements DispatchStrategy {
   const SequentialDispatchStrategy();
 
   @override
-  Future<void> execute<TEvent extends DomainEvent>(
+  Future<void> execute<TEvent>(
     Set<EventHandler<TEvent>> handlers,
     TEvent event,
     List<EventObserver> observers,

--- a/lib/src/event/event_manager.dart
+++ b/lib/src/event/event_manager.dart
@@ -57,7 +57,15 @@ class EventManager {
     TEvent event, [
     DispatchStrategy? dispatchStrategy,
   ]) async {
-    final handlers = _eventHandlerStore.getHandlersFor<TEvent>();
+    late final eventRuntimeType = event.runtimeType;
+
+    final handlers = {
+      // Add handlers for TEvent.
+      ..._eventHandlerStore.getHandlersFor(TEvent),
+      // If a base type was used, add handlers for the runtime type.
+      if (eventRuntimeType != TEvent)
+        ..._eventHandlerStore.getHandlersFor(eventRuntimeType)
+    };
 
     for (final observer in _observers) {
       observer.onDispatch(event, handlers);

--- a/lib/src/event/handler/event_handler_store.dart
+++ b/lib/src/event/handler/event_handler_store.dart
@@ -7,7 +7,7 @@ class EventHandlerStore {
 
   /// Registers the [handler] to a given [TEvent].
   void register<TEvent>(EventHandler<TEvent> handler) {
-    final handlers = _getHandlersFor<TEvent>();
+    final handlers = _getHandlersFor(TEvent);
 
     assert(
       !handlers.contains(handler),
@@ -15,7 +15,7 @@ class EventHandlerStore {
     );
 
     // When the store is being modified, create a new copy.
-    _handlers[TEvent] = <EventHandler<TEvent>>{
+    _handlers[TEvent] = <EventHandler>{
       ...handlers,
       handler,
     };
@@ -23,7 +23,7 @@ class EventHandlerStore {
 
   /// Unregisters the given [handler].
   void unregister<TEvent>(EventHandler<TEvent> handler) {
-    final handlers = _getHandlersFor<TEvent>();
+    final handlers = _getHandlersFor(TEvent);
 
     assert(
       handlers.contains(handler),
@@ -36,18 +36,18 @@ class EventHandlerStore {
     _handlers[TEvent] = update;
   }
 
-  /// Returns all registered [EventHandler]'s for [TEvent].
-  Set<EventHandler<TEvent>> getHandlersFor<TEvent>() {
-    final handlers = _getHandlersFor<TEvent>();
+  /// Returns all registered [EventHandler]'s for [eventType].
+  Set<EventHandler> getHandlersFor(Type eventType) {
+    final handlers = _getHandlersFor(eventType);
 
     return UnmodifiableSetView(handlers);
   }
 
-  Set<EventHandler<TEvent>> _getHandlersFor<TEvent>() {
+  Set<EventHandler> _getHandlersFor(Type eventType) {
     final handlers = _handlers.putIfAbsent(
-      TEvent,
-      () => <EventHandler<TEvent>>{},
-    ) as Set<EventHandler<TEvent>>;
+      eventType,
+      () => <EventHandler>{},
+    );
 
     return handlers;
   }

--- a/lib/src/event/observer/event_observer.dart
+++ b/lib/src/event/observer/event_observer.dart
@@ -7,22 +7,22 @@ abstract interface class EventObserver {
   /// When the [event] is dispatched.
   ///
   /// [handlers] will be executed based on the [DispatchStrategy].
-  void onDispatch<TEvent extends DomainEvent>(
+  void onDispatch<TEvent>(
     TEvent event,
-    Set<EventHandler<TEvent>> handlers,
+    Set<EventHandler> handlers,
   );
 
   /// When the [event] is handled by the [handler].
-  void onHandled<TEvent extends DomainEvent>(
+  void onHandled<TEvent>(
     TEvent event,
-    EventHandler<TEvent> handler,
+    EventHandler handler,
   );
 
   /// When the [event] is failed by the [handler] the [error] contains the
   /// exception object.
-  void onError<TEvent extends DomainEvent>(
+  void onError<TEvent>(
     TEvent event,
-    EventHandler<TEvent> handler,
+    EventHandler handler,
     Object error,
     StackTrace stackTrace,
   );

--- a/test/integration/choreography_test.dart
+++ b/test/integration/choreography_test.dart
@@ -220,9 +220,9 @@ class InventoryAdjustedEventHandler
 
 class LoggingEventObserver implements EventObserver {
   @override
-  void onDispatch<TEvent extends DomainEvent>(
+  void onDispatch<TEvent>(
     TEvent event,
-    Set<EventHandler<TEvent>> handlers,
+    Set<EventHandler> handlers,
   ) {
     print(
       '$LoggingEventObserver: onDispatch $event with ${handlers.length} handlers',
@@ -230,9 +230,9 @@ class LoggingEventObserver implements EventObserver {
   }
 
   @override
-  void onError<TEvent extends DomainEvent>(
+  void onError<TEvent>(
     TEvent event,
-    EventHandler<TEvent> handler,
+    EventHandler handler,
     Object error,
     StackTrace stackTrace,
   ) {
@@ -241,9 +241,9 @@ class LoggingEventObserver implements EventObserver {
   }
 
   @override
-  void onHandled<TEvent extends DomainEvent>(
+  void onHandled<TEvent>(
     TEvent event,
-    EventHandler<TEvent> handler,
+    EventHandler handler,
   ) {
     print('$LoggingEventObserver: onHandled $event -> ${handler.runtimeType}');
   }

--- a/test/integration/event_test.dart
+++ b/test/integration/event_test.dart
@@ -147,6 +147,22 @@ void main() {
         expect(handler3, expected);
         expect(eventHandler.events, expected);
       });
+
+      test('it uses instance event type to dispatch', () async {
+        bool addedEventHandled = false;
+
+        mediator.events
+            .on<_Added>()
+            .subscribeFunction((e) => addedEventHandled = true);
+
+        await mediator.events.dispatch(const _BaseEvent.added());
+
+        expect(
+          addedEventHandled,
+          isTrue,
+          reason: 'Instance type should be used to dispatch events',
+        );
+      });
     });
   });
 }
@@ -160,4 +176,12 @@ class _CollectingEventSubscriber implements EventHandler<DomainIntEvent> {
       events.add(event.count);
     }
   }
+}
+
+sealed class _BaseEvent implements DomainEvent {
+  const factory _BaseEvent.added() = _Added;
+}
+
+final class _Added implements _BaseEvent {
+  const _Added();
 }

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -204,9 +204,9 @@ class EventS implements DomainEvent {
 }
 
 class BaseEvent implements DomainEvent {
-  factory BaseEvent.concrete() = ConcreteEvent;
+  const factory BaseEvent.concrete() = ConcreteEvent;
 }
 
 class ConcreteEvent implements BaseEvent {
-  ConcreteEvent();
+  const ConcreteEvent();
 }

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -202,3 +202,11 @@ class EventS implements DomainEvent {
   @override
   String toString() => 'EventS(s: $s)';
 }
+
+class BaseEvent implements DomainEvent {
+  factory BaseEvent.concrete() = ConcreteEvent;
+}
+
+class ConcreteEvent implements BaseEvent {
+  ConcreteEvent();
+}

--- a/test/unit/event/event_handler/event_handler_store_test.dart
+++ b/test/unit/event/event_handler/event_handler_store_test.dart
@@ -2,6 +2,7 @@ import 'package:dart_mediator/src/event/handler/event_handler_store.dart';
 import 'package:test/test.dart';
 
 import '../../../mocks.dart';
+import '../../../test_data.dart';
 
 void main() {
   group('EventHandlerStore', () {
@@ -57,13 +58,20 @@ void main() {
 
     group('getHandlersFor{TEvent}', () {
       test('it returns the registered handlers', () {
-        final handler = MockEventHandler<int>();
+        final baseHandler = MockEventHandler<BaseEvent>();
+        final concreteHandler = MockEventHandler<ConcreteEvent>();
 
-        eventHandlerStore.register(handler);
+        eventHandlerStore.register(baseHandler);
+        eventHandlerStore.register(concreteHandler);
 
         expect(
-          eventHandlerStore.getHandlersFor<int>(),
-          {handler},
+          eventHandlerStore.getHandlersFor(BaseEvent),
+          {baseHandler},
+        );
+
+        expect(
+          eventHandlerStore.getHandlersFor(ConcreteEvent),
+          {concreteHandler},
         );
       });
     });


### PR DESCRIPTION
This fixes #22 

---

When a redirect factory constructor is used, the `Base` and `Runtime` types differ and both have separate handlers registered. For this case, both handlers will be used when dispatching.

```dart
mediator.events.on<BaseEvent>().subscribeFunction((e) => checkEvent('base', e));
mediator.events.on<ConcreteEvent>().subscribeFunction((e) => checkEvent('concrete', e));

await mediator.events.dispatch(BaseEvent.concrete());
```

Both event handlers will be executed with the `event` having a generic type of `BaseEvent` and runtime type of `ConcreteEvent`.